### PR TITLE
Add GitHub Actions workflow for APK build and release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,83 @@
+name: Build and Release APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 8
+      uses: actions/setup-java@v4
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Cache Gradle packages
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build SSDMobilenet APK
+      run: ./gradlew assembleSSDMobilenetRelease
+
+    - name: Build CaffeSSD APK
+      run: ./gradlew assembleCaffeSSdRelease
+
+    - name: Get version name
+      id: version
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        else
+          echo "version=dev-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.version.outputs.version }}
+        release_name: Release ${{ steps.version.outputs.version }}
+        draft: false
+        prerelease: false
+
+    - name: Upload SSDMobilenet APK
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: app/build/outputs/apk/SSDMobilenet/release/app-SSDMobilenet-release.apk
+        asset_name: SNPECam-SSDMobilenet-${{ steps.version.outputs.version }}.apk
+        asset_content_type: application/vnd.android.package-archive
+
+    - name: Upload CaffeSSD APK
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: app/build/outputs/apk/CaffeSSD/release/app-CaffeSSD-release.apk
+        asset_name: SNPECam-CaffeSSD-${{ steps.version.outputs.version }}.apk
+        asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
- Builds APKs for both SSDMobilenet and CaffeSSD flavors
- Automatically creates releases with APK assets
- Triggered on version tags or manual dispatch
- Uses proper Android build environment with JDK 8

🤖 Generated with [Claude Code](https://claude.ai/code)