### PR TITLE
Fix GitHub Actions workflow - Update to JDK 17 and correct build comm…

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,14 +14,17 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up JDK 8
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
+      with:
+        api-level: 27
+        build-tools: 27.0.3
 
     - name: Cache Gradle packages
       uses: actions/cache@v3
@@ -40,7 +43,7 @@ jobs:
       run: ./gradlew assembleSSDMobilenetRelease
 
     - name: Build CaffeSSD APK
-      run: ./gradlew assembleCaffeSSdRelease
+      run: ./gradlew assembleCaffeSSDRelease
 
     - name: Get version name
       id: version


### PR DESCRIPTION
…ands

- Changed from JDK 8 to JDK 17 to resolve SDK manager compatibility issue
- Added specific API level and build tools configuration
- Fixed CaffeSSD build command typo (assembleCaffeSSdRelease → assembleCaffeSSDRelease)

🤖 Generated with [Claude Code](https://claude.ai/code)