### PR TITLE
Fix gradlew missing issue - Install Gradle manually

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,14 +36,18 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+    - name: Install Gradle
+      run: |
+        wget https://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+        unzip -q gradle-4.10.3-bin.zip
+        sudo mv gradle-4.10.3 /opt/gradle
+        sudo ln -sf /opt/gradle/bin/gradle /usr/bin/gradle
 
     - name: Build SSDMobilenet APK
-      run: ./gradlew assembleSSDMobilenetRelease
+      run: gradle assembleSSDMobilenetRelease
 
     - name: Build CaffeSSD APK
-      run: ./gradlew assembleCaffeSSDRelease
+      run: gradle assembleCaffeSSDRelease
 
     - name: Get version name
       id: version


### PR DESCRIPTION
- Replace gradlew commands with direct gradle installation
- Use Gradle 4.10.3 compatible with Android Gradle Plugin 3.1.3
- Remove gradlew chmod step as file doesn't exist in project

🤖 Generated with [Claude Code](https://claude.ai/code)